### PR TITLE
Workflow exercise updates

### DIFF
--- a/docs/materials/workflows/part1-ex3-complex-dag.md
+++ b/docs/materials/workflows/part1-ex3-complex-dag.md
@@ -130,43 +130,58 @@ Watch Your DAG
 
 Let’s follow the progress of the whole DAG:
 
-1.  Use the `watch` command to run `condor_q -nobatch -wide:80` every 10 seconds:
+1.  Use the `condor_watch_q` command to keep an eye on the running jobs. See more information about this tool [here](https://htcondor.readthedocs.io/en/latest/man-pages/condor_watch_q.html).
 
         :::console
-        username@learn $ watch -n 10 condor_q -nobatch -wide:80
+        username@learn $ condor_watch_q 
 
-    <span style="color:RED">**Here we see DAGMan running:**</span> 
+    <span style="color:RED">**If you're quick enough, you may have seen DAGMan running as the lone job, before it submitted additional job nodes:**</span> 
 
         :::console
-         ID  OWNER  SUBMITTED   RUN_TIME ST PRI SIZE CMD 
-        71.0 roy   6/22 17:39 0+00:00:03 R  0    0.3 condor_dagman
+        BATCH                IDLE  RUN  DONE  TOTAL  JOB_IDS
+        goatbrot.dag+222059     -    1     -      1  222059.0
+
+        [=============================================================================]
+
+        Total: 1 jobs; 1 running
+
+        Updated at 2021-07-28 13:52:57
 
     <span style="color:RED">**DAGMan has submitted the goatbrot jobs, but they haven't started running yet**</span>
     
         :::console
-         ID  OWNER SUBMITTED   RUN_TIME ST PRI SIZE CMD 
-        71.0 roy  6/22 17:39 0+00:00:17 R  0    0.3 condor_dagman 
-        72.0 roy  6/22 17:39 0+00:00:00 I  0    0.0 goatbrot -i 100000 
-        73.0 roy  6/22 17:39 0+00:00:00 I  0    0.0 goatbrot -i 100000 
-        74.0 roy  6/22 17:39 0+00:00:00 I  0    0.0 goatbrot -i 100000 
-        75.0 roy  6/22 17:39 0+00:00:00 I  0    0.0 goatbrot -i 100000
+        BATCH                IDLE  RUN  DONE  TOTAL  JOB_IDS
+        goatbrot.dag+222059     4    1     -      5  222059.0 ... 222063.0
+
+        [===============--------------------------------------------------------------]
+
+        Total: 5 jobs; 4 idle, 1 running
+
+        Updated at 2021-07-28 13:53:53
+
 
     <span style="color:RED">**They're running**</span> 
 
         :::console
-         ID  OWNER SUBMITTED   RUN_TIME ST PRI SIZE CMD
-        71.0 roy  6/22 17:39 0+00:07:15 R  0    0.3 condor_dagman 
-        72.0 roy  6/22 17:39 0+00:00:03 R  0    0.0 goatbrot -i 100000 
-        73.0 roy  6/22 17:39 0+00:00:03 R  0    0.0 goatbrot -i 100000 
-        74.0 roy  6/22 17:39 0+00:00:03 R  0    0.0 goatbrot -i 100000 
-        75.0 roy  6/22 17:39 0+00:00:03 R  0    0.0 goatbrot -i 100000
+        BATCH                IDLE  RUN  DONE  TOTAL  JOB_IDS
+        goatbrot.dag+222059     -    5     -      5  222059.0 ... 222063.0
+        [=============================================================================]
+
+        Total: 5 jobs; 5 running
+
+        Updated at 2021-07-28 13:54:33
 
     <span style="color:RED">**They finished, but DAGMan hasn't noticed yet. It only checks periodically:**</span>
 
         :::console
-         ID  OWNER SUBMITTED   RUN_TIME ST PRI SIZE CMD 
-        71.0 roy  6/22 17:39 0+00:08:46 R  0    0.3 condor_dagman
- 
+        BATCH                IDLE  RUN  DONE  TOTAL  JOB_IDS
+        goatbrot.dag+222059     -    1    4     -      5  222059.0 ... 222063.0
+
+        [##############################################################===============]
+
+        Total: 5 jobs; 4 completed, 1 running
+
+        Updated at 2021-07-28 13:55:13
 
     Eventually, you'll see the montage job submitted, then running, then leave the queue, and then DAGMan will leave the queue.
 

--- a/docs/materials/workflows/part1-ex4-failed-dag.md
+++ b/docs/materials/workflows/part1-ex4-failed-dag.md
@@ -95,7 +95,7 @@ Below is where DAGMan realizes that the montage node failed:
 06/22/12 18:08:42 **** condor_scheduniv_exec.77.0 (condor_DAGMAN) pid 26867 EXITING WITH STATUS 1
 ```
 
-DAGMan notices that one of the jobs failed because it's exit code was non-zero. DAGMan ran as much of the DAG as possible and logged enough information to continue the run when the situation is resolved. Do you see the part where it wrote the rescue DAG?
+DAGMan notices that one of the jobs failed because its exit code was non-zero. DAGMan ran as much of the DAG as possible and logged enough information to continue the run when the situation is resolved. Do you see the part where it wrote the rescue DAG?
 
 Look at the rescue DAG file. It's called a partial DAG because it indicates what part of the DAG has already been completed.
 

--- a/docs/materials/workflows/part1-ex4-failed-dag.md
+++ b/docs/materials/workflows/part1-ex4-failed-dag.md
@@ -95,7 +95,7 @@ Below is where DAGMan realizes that the montage node failed:
 06/22/12 18:08:42 **** condor_scheduniv_exec.77.0 (condor_DAGMAN) pid 26867 EXITING WITH STATUS 1
 ```
 
-DAGMan notices that one of the jobs failed because it's exit code was non-zero. DAGMan ran as much of the DAG as possible and logged enough information to continue the run when the situation is resolved. Do you see the part where it wrote the resuce DAG?
+DAGMan notices that one of the jobs failed because it's exit code was non-zero. DAGMan ran as much of the DAG as possible and logged enough information to continue the run when the situation is resolved. Do you see the part where it wrote the rescue DAG?
 
 Look at the rescue DAG file. It's called a partial DAG because it indicates what part of the DAG has already been completed.
 

--- a/docs/materials/workflows/part1-ex5-challenges.md
+++ b/docs/materials/workflows/part1-ex5-challenges.md
@@ -7,7 +7,7 @@ status: testing
   pre strong { font-style: normal; font-weight: bold; color: \#008; }
 </style>
 
-# Bonus Workflows Exercise 4.5: YOUR Jobs and More on Workflows
+# Bonus Workflows Exercise 1.5: YOUR Jobs and More on Workflows
 
 The objective of this exercise is to learn the very basics of running a set of jobs, where our set is just one job.
 

--- a/docs/materials/workflows/part1-ex5-challenges.md
+++ b/docs/materials/workflows/part1-ex5-challenges.md
@@ -44,7 +44,7 @@ Links to more information:
 
 -   [Pegasus Website](https://pegasus.isi.edu)
 -   [Pegasus Documentation](https://pegasus.isi.edu/documentation)
--   [Pegasus on OSG Connect (covered Thursday)](https://support.opensciencegrid.org/support/solutions/articles/5000639789-pegasus)
+-   [Pegasus on OSG Connect](https://support.opensciencegrid.org/support/solutions/articles/5000639789-pegasus)
 
 If you have any questions or problems, please feel free to contact the Pegasus team by emailing <pegasus-support@isi.edu>
 


### PR DESCRIPTION
Mostly minor tweaks to the workflow exercises.

- use condor_watch_q instead of watch condor_q
- typo fix
- renumber exercise 1.5 (was 4.5 in-text)
- rm 'covered Thursday' from Pegasus link in 1.5
